### PR TITLE
Add base Level scene and HUD

### DIFF
--- a/scenes/HUD.tscn
+++ b/scenes/HUD.tscn
@@ -1,0 +1,34 @@
+[gd_scene load_steps=2 format=2]
+
+[ext_resource path="res://scripts/HUD.gd" type="Script" id=1]
+
+[node name="HUD" type="CanvasLayer"]
+
+layer = 1
+offset = Vector2( 0, 0 )
+rotation = 0.0
+scale = Vector2( 1, 1 )
+transform = Transform2D( 1, 0, 0, 1, 0, 0 )
+script = ExtResource( 1 )
+
+[node name="Message" type="Label" parent="." index="0"]
+
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+margin_left = -20.0
+margin_top = -7.0
+margin_right = 20.0
+margin_bottom = 7.0
+rect_pivot_offset = Vector2( 0, 0 )
+rect_clip_content = false
+mouse_filter = 2
+mouse_default_cursor_shape = 0
+size_flags_horizontal = 1
+size_flags_vertical = 4
+percent_visible = 1.0
+lines_skipped = 0
+max_lines_visible = -1
+
+

--- a/scenes/Level.tscn
+++ b/scenes/Level.tscn
@@ -1,0 +1,10 @@
+[gd_scene load_steps=2 format=2]
+
+[ext_resource path="res://scripts/Level.gd" type="Script" id=1]
+
+[node name="Level" type="Node"]
+
+script = ExtResource( 1 )
+level_name = null
+
+

--- a/scenes/Level1.tscn
+++ b/scenes/Level1.tscn
@@ -1,16 +1,20 @@
-[gd_scene load_steps=4 format=2]
+[gd_scene load_steps=6 format=2]
 
-[ext_resource path="res://scenes/Player.tscn" type="PackedScene" id=1]
-[ext_resource path="res://scenes/WorldComplete.tscn" type="PackedScene" id=2]
-[ext_resource path="res://tiles/DirtAutoTile.tres" type="TileSet" id=3]
+[ext_resource path="res://scenes/Level.tscn" type="PackedScene" id=1]
+[ext_resource path="res://scenes/Player.tscn" type="PackedScene" id=2]
+[ext_resource path="res://scenes/WorldComplete.tscn" type="PackedScene" id=3]
+[ext_resource path="res://tiles/DirtAutoTile.tres" type="TileSet" id=4]
+[ext_resource path="res://scenes/HUD.tscn" type="PackedScene" id=5]
 
-[node name="Level1" type="Node" index="0"]
+[node name="Level" index="0" instance=ExtResource( 1 )]
 
-[node name="Player" parent="." index="0" instance=ExtResource( 1 )]
+level_name = "First level"
+
+[node name="Player" parent="." index="0" instance=ExtResource( 2 )]
 
 position = Vector2( 352, 224 )
 
-[node name="WorldComplete" parent="." index="1" instance=ExtResource( 2 )]
+[node name="WorldComplete" parent="." index="1" instance=ExtResource( 3 )]
 
 position = Vector2( 32, 288 )
 target_world = "res://scenes/Level2.tscn"
@@ -18,7 +22,7 @@ target_world = "res://scenes/Level2.tscn"
 [node name="TileMap" type="TileMap" parent="." index="2"]
 
 mode = 0
-tile_set = ExtResource( 3 )
+tile_set = ExtResource( 4 )
 cell_size = Vector2( 64, 64 )
 cell_quadrant_size = 16
 cell_custom_transform = Transform2D( 1, 0, 0, 1, 0, 0 )
@@ -38,5 +42,7 @@ _sections_unfolded = [ "Cell", "Collision", "Material", "Visibility" ]
 __meta__ = {
 "_edit_lock_": true
 }
+
+[node name="HUD" parent="." index="3" instance=ExtResource( 5 )]
 
 

--- a/scenes/Level2.tscn
+++ b/scenes/Level2.tscn
@@ -1,29 +1,35 @@
-[gd_scene load_steps=5 format=2]
+[gd_scene load_steps=7 format=2]
 
-[ext_resource path="res://scenes/Player.tscn" type="PackedScene" id=1]
-[ext_resource path="res://scenes/WorldComplete.tscn" type="PackedScene" id=2]
-[ext_resource path="res://scenes/Enemy.tscn" type="PackedScene" id=3]
-[ext_resource path="res://tiles/DirtAutoTile.tres" type="TileSet" id=4]
+[ext_resource path="res://scenes/Level.tscn" type="PackedScene" id=1]
+[ext_resource path="res://scenes/Player.tscn" type="PackedScene" id=2]
+[ext_resource path="res://scenes/WorldComplete.tscn" type="PackedScene" id=3]
+[ext_resource path="res://scenes/Enemy.tscn" type="PackedScene" id=4]
+[ext_resource path="res://scenes/HUD.tscn" type="PackedScene" id=5]
+[ext_resource path="res://tiles/DirtAutoTile.tres" type="TileSet" id=6]
 
-[node name="Level2" type="Node"]
+[node name="Level" index="0" instance=ExtResource( 1 )]
 
-[node name="Player" parent="." index="0" instance=ExtResource( 1 )]
+level_name = "Second level"
+
+[node name="Player" parent="." index="0" instance=ExtResource( 2 )]
 
 position = Vector2( -160, 160 )
 
-[node name="WorldComplete" parent="." index="1" instance=ExtResource( 2 )]
+[node name="WorldComplete" parent="." index="1" instance=ExtResource( 3 )]
 
 position = Vector2( 544, 160 )
 target_world = "res://scenes/Level1.tscn"
 
-[node name="Enemy" parent="." index="2" instance=ExtResource( 3 )]
+[node name="Enemy" parent="." index="2" instance=ExtResource( 4 )]
 
 position = Vector2( 224, 288 )
 
-[node name="TileMap" type="TileMap" parent="." index="3"]
+[node name="HUD" parent="." index="3" instance=ExtResource( 5 )]
+
+[node name="TileMap" type="TileMap" parent="." index="4"]
 
 mode = 0
-tile_set = ExtResource( 4 )
+tile_set = ExtResource( 6 )
 cell_size = Vector2( 64, 64 )
 cell_quadrant_size = 16
 cell_custom_transform = Transform2D( 1, 0, 0, 1, 0, 0 )

--- a/scripts/HUD.gd
+++ b/scripts/HUD.gd
@@ -1,0 +1,10 @@
+extends CanvasLayer
+
+func show_message(message):
+	$Message.text = message
+	$Message.show()
+
+func show_start_level_message(message):
+	show_message(message)
+	yield(get_tree().create_timer(2.0), "timeout")
+	$Message.hide()

--- a/scripts/Level.gd
+++ b/scripts/Level.gd
@@ -1,0 +1,9 @@
+extends Node
+
+export(String) var level_name
+
+signal start_level
+
+func _ready():
+	if has_node("HUD"):
+		$HUD.show_start_level_message(level_name)


### PR DESCRIPTION
The new `Level` scene will be used as root node of all levels. It provides only level name for now, but could handle more things related to given level scene in the future.

`HUD` is currently only able to show name of the level for 2 seconds after level is loaded. It'll contain all character / level info in the future.