### PR TITLE
Moving platforms

### DIFF
--- a/scenes/Level3.tscn
+++ b/scenes/Level3.tscn
@@ -1,0 +1,55 @@
+[gd_scene load_steps=10 format=2]
+
+[ext_resource path="res://scenes/Level.tscn" type="PackedScene" id=1]
+[ext_resource path="res://scenes/HUD.tscn" type="PackedScene" id=2]
+[ext_resource path="res://tiles/DirtAutoTile.tres" type="TileSet" id=3]
+[ext_resource path="res://scenes/LevelExit.tscn" type="PackedScene" id=4]
+[ext_resource path="res://scenes/MovingPlatform.tscn" type="PackedScene" id=5]
+[ext_resource path="res://scenes/Player.tscn" type="PackedScene" id=6]
+
+[sub_resource type="Curve2D" id=1]
+
+_data = {
+"points": PoolVector2Array( 0, 0, 0, 0, -12, 0, 0, 0, 0, 0, 148, 0 )
+}
+
+[sub_resource type="Curve2D" id=2]
+
+_data = {
+"points": PoolVector2Array( 0, 0, 0, 0, 1.0898, -160, 0, 0, 0, 0, 1.0898, 0 )
+}
+
+[sub_resource type="Curve2D" id=3]
+
+_data = {
+"points": PoolVector2Array( 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -140, -128 )
+}
+
+[node name="Level" instance=ExtResource( 1 )]
+id = "1-3"
+
+[node name="HUD" parent="." index="1" instance=ExtResource( 2 )]
+
+[node name="TileMap" type="TileMap" parent="." index="2"]
+tile_set = ExtResource( 3 )
+format = 1
+tile_data = PoolIntArray( 196611, 0, 196608, 196612, 0, 196609, 196613, 0, 196609, 196614, 0, 196610, 196620, 0, 196608, 196621, 0, 196609, 196622, 0, 196609, 196623, 0, 196610 )
+
+[node name="LevelExit" parent="." index="3" instance=ExtResource( 4 )]
+position = Vector2( 991.964, 160 )
+
+[node name="HorizontalPlatform" parent="." index="4" instance=ExtResource( 5 )]
+position = Vector2( 492, 192 )
+curve = SubResource( 1 )
+
+[node name="VerticalPlatform" parent="." index="5" instance=ExtResource( 5 )]
+position = Vector2( 40, 250 )
+curve = SubResource( 2 )
+
+[node name="MovingPlatform" parent="." index="6" instance=ExtResource( 5 )]
+position = Vector2( -130, 128 )
+curve = SubResource( 3 )
+
+[node name="Player" parent="." index="7" instance=ExtResource( 6 )]
+position = Vector2( 280, 160 )
+

--- a/scenes/MovingPlatform.tscn
+++ b/scenes/MovingPlatform.tscn
@@ -18,6 +18,8 @@ motion/sync_to_physics = true
 
 [node name="TileMap" type="TileMap" parent="Platform"]
 tile_set = ExtResource( 2 )
+collision_layer = 0
+collision_mask = 0
 format = 1
 tile_data = PoolIntArray( 0, 0, 196608, 1, 0, 196610 )
 

--- a/scenes/MovingPlatform.tscn
+++ b/scenes/MovingPlatform.tscn
@@ -1,0 +1,30 @@
+[gd_scene load_steps=4 format=2]
+
+[ext_resource path="res://scripts/MovingPlatform.gd" type="Script" id=1]
+[ext_resource path="res://tiles/DirtAutoTile.tres" type="TileSet" id=2]
+
+[sub_resource type="RectangleShape2D" id=1]
+
+extents = Vector2( 64, 32 )
+
+[node name="MovingPlatform" type="Path2D"]
+curve = null
+script = ExtResource( 1 )
+
+[node name="Platform" type="KinematicBody2D" parent="."]
+collision_layer = 4
+collision_mask = 0
+motion/sync_to_physics = true
+
+[node name="TileMap" type="TileMap" parent="Platform"]
+tile_set = ExtResource( 2 )
+format = 1
+tile_data = PoolIntArray( 0, 0, 196608, 1, 0, 196610 )
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Platform"]
+position = Vector2( 64, 32 )
+shape = SubResource( 1 )
+
+[node name="AnimationPlayer" type="AnimationPlayer" parent="."]
+playback_process_mode = 0
+

--- a/scenes/world/World.tscn
+++ b/scenes/world/World.tscn
@@ -28,5 +28,10 @@ position = Vector2( 296, 90 )
 level_id = "1-2"
 texture = ExtResource( 5 )
 
+[node name="1-3" parent="Levels" instance=ExtResource( 4 )]
+position = Vector2( 418, 192 )
+level_id = "1-3"
+texture = ExtResource( 5 )
+
 [node name="WorldMenu" parent="." instance=ExtResource( 6 )]
 

--- a/scripts/Game.gd
+++ b/scripts/Game.gd
@@ -10,7 +10,12 @@ var levels = {
         "scene": "res://scenes/Level2.tscn",
         "entrance_node": "/root/World/Levels/1-2",
         "name": "Second level",
-    }
+    },
+    "1-3": {
+        "scene": "res://scenes/Level3.tscn",
+        "entrance_node": "/root/World/Levels/1-3",
+        "name": "Platform level",
+    },
 }
 var current_level_id = null
 

--- a/scripts/MovingPlatform.gd
+++ b/scripts/MovingPlatform.gd
@@ -1,0 +1,28 @@
+extends Path2D
+
+export var SPEED = 100
+
+func _ready():
+    assert(curve.get_point_count() == 2)
+
+    var first_point = curve.get_point_position(0)
+    var second_point = curve.get_point_position(1)
+    var curve_length = curve.get_baked_length()
+
+    # Animation is there and back, so we have to multiply it by 2
+    var animation_length = curve_length * 2 / SPEED
+
+    var movement_animation = Animation.new()
+    movement_animation.length = animation_length
+    movement_animation.loop = true
+
+    var track_index = movement_animation.add_track(Animation.TYPE_VALUE)
+    movement_animation.track_set_path(track_index, "Platform:position")
+    movement_animation.track_insert_key(track_index, 0.0, first_point)
+    movement_animation.track_insert_key(track_index, animation_length / 2, second_point)
+    movement_animation.track_insert_key(track_index, animation_length, first_point)
+
+    var animation_name = "movement"
+    $AnimationPlayer.add_animation(animation_name, movement_animation)
+    $AnimationPlayer.playback_speed = 1
+    $AnimationPlayer.play(animation_name)

--- a/scripts/Player.gd
+++ b/scripts/Player.gd
@@ -25,10 +25,11 @@ func _process(delta):
         $AnimatedSprite.flip_h = true
         $AnimatedSprite.play("Run")
 
-    if _motion.y < 0:
-        $AnimatedSprite.play("Jump")
-    elif _motion.y > 0:
-        $AnimatedSprite.play("Fall")
+    if not is_on_floor():
+        if _motion.y < 0:
+            $AnimatedSprite.play("Jump")
+        elif _motion.y > 0:
+            $AnimatedSprite.play("Fall")
 
 func _physics_process(delta):
     _motion.y += GRAVITY

--- a/scripts/Player.gd
+++ b/scripts/Player.gd
@@ -10,6 +10,8 @@ const JUMP_HEIGHT_LOW = -420
 const JUMP_HEIGHT_HIGH = -550
 const DRAG_FACTOR_LAND = 0.0001
 const DRAG_FACTOR_AIR = 0.1
+const SNAP_TO_FLOOR = Vector2(0, 32)
+const NO_SNAP = Vector2(0, 0)
 
 var _motion = Vector2()
 var _apply_drag = false
@@ -63,9 +65,9 @@ func _physics_process(delta):
     if _jumping and _motion.y > 0:
         _jumping = false
 
-    var snap = Vector2(0, 32)
+    var snap = SNAP_TO_FLOOR
 
     if _jumping:
-        snap = Vector2(0, 0)
+        snap = NO_SNAP
 
     _motion = move_and_slide_with_snap(_motion, snap, UP)

--- a/scripts/Player.gd
+++ b/scripts/Player.gd
@@ -13,6 +13,7 @@ const DRAG_FACTOR_AIR = 0.1
 
 var _motion = Vector2()
 var _apply_drag = false
+var _jumping = false
 
 func _process(delta):
     if _apply_drag or _motion.x == 0:
@@ -47,12 +48,23 @@ func _physics_process(delta):
     if is_on_floor():
         if jump_high:
             _motion.y = JUMP_HEIGHT_HIGH
+            _jumping = true
         elif jump_low:
             _motion.y = JUMP_HEIGHT_LOW
+            _jumping = true
+
         if _apply_drag:
             _motion.x = Math.decay(_motion.x, 0, DRAG_FACTOR_LAND, delta)
     else:
         if _apply_drag:
             _motion.x = Math.decay(_motion.x, 0, DRAG_FACTOR_AIR, delta)
 
-    _motion = move_and_slide(_motion, UP)
+    if _jumping and _motion.y > 0:
+        _jumping = false
+
+    var snap = Vector2(0, 32)
+
+    if _jumping:
+        snap = Vector2(0, 0)
+
+    _motion = move_and_slide_with_snap(_motion, snap, UP)


### PR DESCRIPTION
This adds possibility to instance moving platforms. This PR is more WIP-ish with room for discussion.

Root scene is `Path2D` which sets 2 points between which the platform moves. They can be set in any direction. It doesn't need to be strictly horizontal or vertical. For now it forces designer to set exactly 2 points. `Path2D` doesn't have its `Curve` set upon instancing. There's a quirk (feature they say) where any instance of `Path2D` points to the same `Curve`, so it has to be unset in base scene and designer has to set it manually for each instance. It's not a big deal, but it's something one has to know about.

At this moment each platform is not customizable at all and is forced to be 2 tiles wide `TileMap`. It's good enough for testing, but I think it'd be the easiest to set sprite (as an exported variable) for each instance of a platform. Or maybe even better, to let designer choose from types of various platforms saved in some config dictionary.

I think there's still a problem with movement of player on horizontal platform where its speed is faster if they go in direction of platform's movement and slower if they go against it. But I cannot confirm because numbers from motion variables seem to be right. We'll have to investigate this.

One more idea (perhaps for the future) is to let designer set more than 2 points that would act as waypoints for given platform and it'd follow it. That would make them more flexible and it could enable us to create some interesting levels.

Closes #16 